### PR TITLE
Encoding fixes

### DIFF
--- a/R/AugmentDataQualityFiles.R
+++ b/R/AugmentDataQualityFiles.R
@@ -80,7 +80,8 @@ augmentDataQualityFiles <- function(sourceFolders) {
         currentQualityFile$CheckResults <- currentChecks
       }
 
-      write_json(currentQualityFile, file.path(releases[i], "dq-result.json"))
+      jsonlite::toJSON(currentQualityFile) |>
+      write(file.path(releases[i], "dq-result.json"))
 
       # Maintain only the last two loaded datasets
       if (length(loadedData) > 2) {

--- a/extras/BuildAresCohortReport.R
+++ b/extras/BuildAresCohortReport.R
@@ -3,6 +3,7 @@ library(FeatureExtraction)
 library(CohortDiagnostics)
 library(DatabaseConnector)
 library(dplyr)
+library(readr)
 library(tools)
 library(arrow)
 library(stringr)
@@ -301,21 +302,10 @@ buildAresCohortReport <- function(
 
   message("Export data to ARES")
 
-  ## index_event_breakdown.csv may contain UTF Byte Order Mark (BOM), which
-  ## prepends first column name in the CSV making it "∩..concept_id" instead of
-  ## "concept_id" or causing failure
-  saveEncoding <- getOption("encoding")
   indexEventBreakdownData <-
-    tryCatch(
-      expr = {
-        message("Changing encoding to read index_event_breakdown.csv: ", saveEncoding, " -> UTF-8-BOM")
-        options("encoding" = "UTF-8-BOM")
-        read.csv(file.path(releaseFolder, "temp", "index_event_breakdown.csv"))
-      },
-      finally = {
-        options("encoding" = saveEncoding)
-        message("Encoding was restored: ", saveEncoding)
-      }
+    readr::read_csv(
+      file = file.path(releaseFolder, "temp", "index_event_breakdown.csv"),
+      show_col_types = FALSE
     )
 
   cohortsTable <-


### PR DESCRIPTION
* jsonlite::write_json() produces incorrect results when writing multibyte chars, encoding is set to UTF-8 and locale uses code page 1252
* readr is better option to read index_event_breakdown.csv since it was written using readr too and it takes care of BOM