### PR TITLE
Fix empty results from getSourceReleaseKey()

### DIFF
--- a/R/GetSourceReleaseKey.R
+++ b/R/GetSourceReleaseKey.R
@@ -6,14 +6,14 @@
 #'
 #' @export
 getSourceReleaseKey <- function(connectionDetails, cdmDatabaseSchema) {
-  sql <- "SELECT * from @cdmDatabaseSchema.cdm_source"
+  sql <- "SELECT cdm_source_abbreviation, cdm_release_date from @cdmDatabaseSchema.cdm_source"
   renderedSql <- SqlRender::render(sql,cdmDatabaseSchema = cdmDatabaseSchema)
   translatedRenderedSql <- SqlRender::translate(renderedSql,connectionDetails$dbms)
 
   connection <- DatabaseConnector::connect(connectionDetails)
   results <- DatabaseConnector::querySql(connection = connection, sql = translatedRenderedSql)
-  releaseId <- format(lubridate::ymd(results[1,"CDM_RELEASE_DATE"]),"%Y%m%d")
-  sourceKey <- gsub(" ", "_", results[1,"CDM_SOURCE_ABBREVIATION"])
+  releaseId <- format(lubridate::ymd(results[1,"cdm_release_date"]),"%Y%m%d")
+  sourceKey <- gsub(" ", "_", results[1,"cdm_source_abbreviation"])
 
   return(file.path(sourceKey,releaseId))
 }


### PR DESCRIPTION
Looks like new version of DatabaseConnector requires lower case column names. At least this fixed empty results.